### PR TITLE
Patched cover_url and genres metadata

### DIFF
--- a/imdbinfo/models.py
+++ b/imdbinfo/models.py
@@ -64,7 +64,7 @@ class MovieDetail(BaseModel):
     metacritic_rating: Optional[int] = None
     votes: Optional[int] = None
     trailers: List[str] = []
-    genres: List[str] = []
+    genres: Optional[List[str]] = None
     interests: List[str] = []
     worldwide_gross: Optional[str] = None
     production_budget: Optional[str] = None

--- a/imdbinfo/models.py
+++ b/imdbinfo/models.py
@@ -49,7 +49,7 @@ class MovieDetail(BaseModel):
     title: str
     kind: Optional[str] = None
     url: str = ""
-    cover_url: str
+    cover_url: Optional[str] = None
     plot: Optional[str] = None
     release_date: Optional[str] = None
     languages: List[str] = []

--- a/imdbinfo/parsers.py
+++ b/imdbinfo/parsers.py
@@ -17,14 +17,21 @@ def parse_json_movie(raw_json) -> Optional[MovieDetail]:
     data['kind'] = mainColumnData['titleType']['id']
     data['metacritic_rating'] = mainColumnData['metacritic']['metascore']['score'] if mainColumnData[
         'metacritic'] else None
-    data['cover_url'] = aboveTheFoldData['primaryImage']['url']
+    data["cover_url"] = (
+        aboveTheFoldData["primaryImage"]["url"]
+        if aboveTheFoldData["primaryImage"]
+        else None
+    )    
     data['plot'] = mainColumnData['plot']['plotText']['plainText'] if mainColumnData['plot'] else None
     release_date = mainColumnData['releaseDate']
     data['year'] = aboveTheFoldData['releaseYear']['year']
     data['duration'] = aboveTheFoldData['runtime']['seconds'] / 60 if aboveTheFoldData['runtime'] else None
     data['rating'] = mainColumnData['ratingsSummary']['aggregateRating']
     data['votes'] = mainColumnData['ratingsSummary']['voteCount']
-    data['genres'] = [genre['genre']['text'] for genre in mainColumnData['titleGenres']['genres']]
+    if title_genre := mainColumnData["titleGenres"]:
+        for genre in title_genre["genres"]:
+            if genre_genre := genre["genre"]:
+                data["genres"] = genre_genre.get("text")
     data[
         'worldwide_gross'] = f"{mainColumnData['worldwideGross']['total']['amount']} {mainColumnData['worldwideGross']['total']['currency']}" if \
         mainColumnData['worldwideGross'] else None


### PR DESCRIPTION
Closes #9 
Also fixes an issue in which an exception is thrown if there is no genres metadata available for a movie.