### PR TITLE
Fix parsing defaults and runtime calculations

### DIFF
--- a/imdbinfo/models.py
+++ b/imdbinfo/models.py
@@ -1,5 +1,5 @@
 from typing import Optional, List, Dict, Tuple
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 class Person(BaseModel):
     name: str
@@ -52,36 +52,36 @@ class MovieDetail(BaseModel):
     cover_url: str
     plot: Optional[str] = None
     release_date: Optional[str] = None
-    languages: List[str] = []
-    certificates: Dict[str, Tuple[str, str]] = {}
-    directors: List[Person] = []
-    cast: List[Person] = []
-    stars: List[Person] = []
+    languages: List[str] = Field(default_factory=list)
+    certificates: Dict[str, Tuple[str, str]] = Field(default_factory=dict)
+    directors: List[Person] = Field(default_factory=list)
+    cast: List[Person] = Field(default_factory=list)
+    stars: List[Person] = Field(default_factory=list)
     year: Optional[int] = None
     duration: Optional[int] = None
-    country_codes: List[str] = []
+    country_codes: List[str] = Field(default_factory=list)
     rating: Optional[float] = None
     metacritic_rating: Optional[int] = None
     votes: Optional[int] = None
-    trailers: List[str] = []
-    genres: List[str] = []
-    interests: List[str] = []
+    trailers: List[str] = Field(default_factory=list)
+    genres: List[str] = Field(default_factory=list)
+    interests: List[str] = Field(default_factory=list)
     worldwide_gross: Optional[str] = None
     production_budget: Optional[str] = None
-    storyline_keywords: List[str] = []
-    filming_locations: List[str] = []
-    sound_mixes: List[str] = []
-    processes: List[str] = []
-    printed_formats: List[str] = []
-    negative_formats: List[str] = []
-    laboratories: List[str] = []
-    colorations: List[str] = []
-    cameras: List[str] = []
-    aspect_ratios: List[Tuple[str, str]] = []
-    summaries: List[str] = []
-    synopses: List[str] = []
-    production: List[str] = []
-    categories: Dict[str, List[Person]] = {}
+    storyline_keywords: List[str] = Field(default_factory=list)
+    filming_locations: List[str] = Field(default_factory=list)
+    sound_mixes: List[str] = Field(default_factory=list)
+    processes: List[str] = Field(default_factory=list)
+    printed_formats: List[str] = Field(default_factory=list)
+    negative_formats: List[str] = Field(default_factory=list)
+    laboratories: List[str] = Field(default_factory=list)
+    colorations: List[str] = Field(default_factory=list)
+    cameras: List[str] = Field(default_factory=list)
+    aspect_ratios: List[Tuple[str, str]] = Field(default_factory=list)
+    summaries: List[str] = Field(default_factory=list)
+    synopses: List[str] = Field(default_factory=list)
+    production: List[str] = Field(default_factory=list)
+    categories: Dict[str, List[Person]] = Field(default_factory=dict)
 
 class MovieInfo(BaseModel):
 
@@ -108,5 +108,5 @@ class MovieInfo(BaseModel):
         )
 
 class SearchResult(BaseModel):
-    titles: List[MovieInfo] = []
-    names: List[Person] = []
+    titles: List[MovieInfo] = Field(default_factory=list)
+    names: List[Person] = Field(default_factory=list)

--- a/imdbinfo/parsers.py
+++ b/imdbinfo/parsers.py
@@ -15,13 +15,14 @@ def parse_json_movie(raw_json) -> Optional[MovieDetail]:
     data['url'] = f"https://www.imdb.com/title/{data['imdbId']}/"
     data['title'] = aboveTheFoldData['originalTitleText']['text']
     data['kind'] = mainColumnData['titleType']['id']
-    data['metacritic_rating'] = mainColumnData['metacritic']['metascore']['score'] if mainColumnData[
-        'metacritic'] else None
+    meta = mainColumnData.get('metacritic')
+    data['metacritic_rating'] = meta['metascore']['score'] if meta else None
     data['cover_url'] = aboveTheFoldData['primaryImage']['url']
     data['plot'] = mainColumnData['plot']['plotText']['plainText'] if mainColumnData['plot'] else None
     release_date = mainColumnData['releaseDate']
     data['year'] = aboveTheFoldData['releaseYear']['year']
-    data['duration'] = aboveTheFoldData['runtime']['seconds'] / 60 if aboveTheFoldData['runtime'] else None
+    runtime = aboveTheFoldData.get('runtime')
+    data['duration'] = runtime['seconds'] // 60 if runtime else None
     data['rating'] = mainColumnData['ratingsSummary']['aggregateRating']
     data['votes'] = mainColumnData['ratingsSummary']['voteCount']
     data['genres'] = [genre['genre']['text'] for genre in mainColumnData['titleGenres']['genres']]


### PR DESCRIPTION
## Summary
- avoid mutable default values in data models
- handle missing metacritic info gracefully and parse runtime as integer minutes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687f72c8f7208324932b5237c8f0cc42