### PR TITLE
fix: add 'languages_text' and 'countries' to field validator for impr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,3 +106,6 @@
 ## v0.5.3
 - **Movie Reviews Extraction:** Added new `get_reviews` function to fetch user reviews for any IMDb title, including review text, ratings, author information, and helpfulness votes
 - **Trivia Information Access:** Added new `get_trivia` function to retrieve interesting trivia facts about movies and TV shows, complete with interest scores from the community
+
+## v0.5.4
+- **Bug Fixes and Improvements:** Fixed bug in get_movies for movies without country pr languages

--- a/examples/usage_example.py
+++ b/examples/usage_example.py
@@ -33,8 +33,11 @@ movies_list = [
     "tt11771594", # American Pie Presents: Girls' Rules (video)
     "tt37195825" , # Talking Heads: Psycho Killer (musicVideo)
     "tt33501878", #title akas
-
-
+    "tt22477502",
+    "tt28813819",
+    "tt26901778",
+    "tt0269009",
+    "tt11022278",
 ]
 
 for imdb_id in movies_list:

--- a/imdbinfo/models.py
+++ b/imdbinfo/models.py
@@ -217,7 +217,7 @@ class MovieDetail(SeriesMixin, BaseModel):
     categories: Dict[str, List[Union[Person, CastMember]]] = {}
     company_credits: Dict[str, List[CompanyInfo]] = {}
 
-    @field_validator("languages", "country_codes", "genres", mode="before")
+    @field_validator("languages", "country_codes", "genres","languages_text","countries", mode="before")
     def none_is_list(cls, value):
         if value is None:
             return []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imdbinfo"
-version = "0.5.3"
+version = "0.5.4"
 description = "A Python service for querying IMDb data"
 readme = "README.md"
 license = { file = "LICENSE.txt" }


### PR DESCRIPTION
This pull request updates the package to version 0.5.4 and addresses a bug in the `get_movies` function related to handling movies without country or language information. It also improves model validation and updates example usage.

Bug fixes and improvements:

* Fixed a bug in the `get_movies` function to properly handle movies that lack country or language data, as noted in the changelog.

Model validation enhancements:

* Updated the `MovieDetail` model's field validator to include `languages_text` and `countries`, ensuring that these fields are converted to empty lists if missing or `None`.

Documentation and versioning:

* Bumped the package version to `0.5.4` in `pyproject.toml`.
* Added a new section to the `CHANGELOG.md` for version 0.5.4, documenting the bug fix.

Examples:

* Expanded the `movies_list` in `examples/usage_example.py` with several new IMDb IDs for demonstration purposes.…oved data handling