### PR TITLE
fix: handle null credits in stars parser

### DIFF
--- a/imdbinfo/parsers.py
+++ b/imdbinfo/parsers.py
@@ -232,7 +232,7 @@ def _parse_principal_credits_v2_stars(principal_credits_groups) -> List[Person]:
     stars: List[Person] = []
     for group in principal_credits_groups:
         if group.get("grouping", {}).get("text") == "Stars":
-            for credit in group.get("credits", []):
+            for credit in (group.get("credits") or []):
                 stars.append(Person.from_cast(credit))
     return stars
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -216,3 +216,33 @@ def test_parse_awards_with_partial_prestigious_award_none():
     assert awards.wins == 1
     assert awards.nominations == 2
     assert "prestigious_award" not in awards
+
+
+def test_parse_principal_credits_v2_stars_with_none_credits():
+    """Test that _parse_principal_credits_v2_stars handles None credits gracefully.
+
+    This reproduces a bug where movies with incomplete cast data (credits=None)
+    would cause a TypeError: 'NoneType' object is not iterable.
+    See: https://www.imdb.com/title/tt28629017/
+    """
+    # Case 1: credits is explicitly None
+    data_with_none_credits = [
+        {'grouping': {'text': 'Stars'}, 'credits': None}
+    ]
+    result = parsers._parse_principal_credits_v2_stars(data_with_none_credits)
+    assert result == []
+
+    # Case 2: credits key is missing entirely
+    data_without_credits = [
+        {'grouping': {'text': 'Stars'}}
+    ]
+    result = parsers._parse_principal_credits_v2_stars(data_without_credits)
+    assert result == []
+
+    # Case 3: entire input is None
+    result = parsers._parse_principal_credits_v2_stars(None)
+    assert result == []
+
+    # Case 4: empty list
+    result = parsers._parse_principal_credits_v2_stars([])
+    assert result == []


### PR DESCRIPTION
When parsing movies with incomplete cast data, the credits field within principalCreditsV2 can be explicitly null. The previous code used group.get("credits", []) which only returns the default when the key is missing, not when its value is None.

Changed to (group.get("credits") or []) to handle both cases.

Fixes TypeError: 'NoneType' object is not iterable when fetching movies like tt28629017 with incomplete cast information.

Fixes https://github.com/tveronesi/imdbinfo/issues/120