### PR TITLE
Develop

### DIFF
--- a/imdbinfo/parsers.py
+++ b/imdbinfo/parsers.py
@@ -237,7 +237,7 @@ def _parse_principal_credits_v2_stars(principal_credits_groups) -> List[Person]:
     stars: List[Person] = []
     for group in principal_credits_groups:
         if group.get("grouping", {}).get("text") == "Stars":
-            for credit in group.get("credits", []):
+            for credit in (group.get("credits") or []):
                 stars.append(Person.from_cast(credit))
     return stars
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -216,3 +216,33 @@ def test_parse_awards_with_partial_prestigious_award_none():
     assert awards.wins == 1
     assert awards.nominations == 2
     assert "prestigious_award" not in awards
+
+
+def test_parse_principal_credits_v2_stars_with_none_credits():
+    """Test that _parse_principal_credits_v2_stars handles None credits gracefully.
+
+    This reproduces a bug where movies with incomplete cast data (credits=None)
+    would cause a TypeError: 'NoneType' object is not iterable.
+    See: https://www.imdb.com/title/tt28629017/
+    """
+    # Case 1: credits is explicitly None
+    data_with_none_credits = [
+        {'grouping': {'text': 'Stars'}, 'credits': None}
+    ]
+    result = parsers._parse_principal_credits_v2_stars(data_with_none_credits)
+    assert result == []
+
+    # Case 2: credits key is missing entirely
+    data_without_credits = [
+        {'grouping': {'text': 'Stars'}}
+    ]
+    result = parsers._parse_principal_credits_v2_stars(data_without_credits)
+    assert result == []
+
+    # Case 3: entire input is None
+    result = parsers._parse_principal_credits_v2_stars(None)
+    assert result == []
+
+    # Case 4: empty list
+    result = parsers._parse_principal_credits_v2_stars([])
+    assert result == []


### PR DESCRIPTION
This pull request improves the robustness of the `_parse_principal_credits_v2_stars` function in `imdbinfo/parsers.py` by ensuring it gracefully handles cases where the `credits` field is missing or set to `None`. Additionally, comprehensive tests have been added to verify the function's behavior with various edge cases.

**Bug fix and robustness improvements:**

* Updated `_parse_principal_credits_v2_stars` to safely handle cases where `credits` is `None` by using `(group.get("credits") or [])` instead of just `group.get("credits", [])`, preventing a potential `TypeError`.

**Testing enhancements:**

* Added a new test `test_parse_principal_credits_v2_stars_with_none_credits` in `tests/test_parsers.py` to cover scenarios where the `credits` field is `None`, missing, the input is `None`, or the input is an empty list, ensuring the function returns an empty list in all these cases.