### PR TITLE
Remove 'accept-language' from HTTP headers

### DIFF
--- a/imdbinfo/services.py
+++ b/imdbinfo/services.py
@@ -127,7 +127,6 @@ USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
 HEADERS = {
             "connection": "keep-alive",
             'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
-            'accept-language': 'de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7,fr;q=0.6',
             'cache-control': 'no-cache',
             'pragma': 'no-cache',
             'priority': 'u=0, i',


### PR DESCRIPTION
Removed 'accept-language' header from HTTP headers to fix language issues.