### PR TITLE
Feature/bulked episode improve

### DIFF
--- a/imdbinfo/models.py
+++ b/imdbinfo/models.py
@@ -533,7 +533,7 @@ class BulkedEpisode(BaseModel):
         )
 
     def __str__(self):
-        return f"{self.title} ({self.release_date or 'N/A'}) - {self.imdbId} ({self.kind or 'N/A'})"
+        return f"{self.title} S{str(self.season_number).zfill(2)}-E{str(self.episode_number).zfill(2)}({self.release_date or 'N/A'}) - {self.imdbId} ({self.kind or 'N/A'})"
 
 
 class SeasonEpisodesList(BaseModel):

--- a/imdbinfo/models.py
+++ b/imdbinfo/models.py
@@ -495,6 +495,8 @@ class BulkedEpisode(BaseModel):
     id: str  # id without 'tt' prefix, e.g. '1234567'
     imdbId: str
     imdb_id: str
+    season_number: Optional[int] = None
+    episode_number: Optional[int] = None
     title: str
     plot: str
     image_url: Optional[str] = None
@@ -516,6 +518,8 @@ class BulkedEpisode(BaseModel):
             id=data["titleId"].replace("tt", ""),
             imdbId=data["titleId"],
             imdb_id=data["titleId"].replace("tt", ""),
+            season_number=data.get("series", {}).get("seasonNumber", None),
+            episode_number=data.get("series", {}).get("episodeNumber", None),
             title=data["titleText"],
             genres=data.get("genres") or [],
             plot=data.get("plot", ""),


### PR DESCRIPTION
This pull request updates the `BulkedEpisode` model in `imdbinfo/models.py` to better support TV episode data by including season and episode numbers. It also improves the string representation of episodes to include this new information.

Enhancements to episode data modeling:

* Added `season_number` and `episode_number` as optional integer fields to the `BulkedEpisode` model to explicitly represent episode positioning within a series.
* Updated the `from_bulked_episode_data` class method to extract `season_number` and `episode_number` from the input data, if available.

Improvements to string representation:

* Modified the `__str__` method of `BulkedEpisode` to display the season and episode numbers in the format `Sxx-Exx` for clearer identification of episodes.